### PR TITLE
selfupdate.py: now allows updating to different repo/fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ The usage of StaSh is in principle similar to Bash. A few things to note are:
     * `edit.py` - Open any text type files in Pythonista editor
     * `find.py` - Powerful file searching tool
     * `fg.py` - Bring a background job to foreground
-    * `gci.py - Interface to Python's built-in garbage collector
+    * `gci.py` - Interface to Python's built-in garbage collector
     * `git.py` - Git client ported from shellista
     * `grep.py` - search contents of file(s)
     * `httpserver.py` - A simple HTTP server with upload function (ripped from

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ environment and great treasures may be found within.
 **StaSh can be easily installed via one line of python command**
 (courtesy of [@whitone](https://forum.omz-software.com/user/whitone)). 
 ```Python
-import requests as r; exec r.get('http://bit.ly/get-stash').text
+import requests as r; exec(r.get('http://bit.ly/get-stash').text)
 ```
 Simply copy the above line, paste into Pythonista interactive prompt and
 execute. It installs StaSh as a Python module under the `site-packages` 
@@ -222,6 +222,7 @@ The usage of StaSh is in principle similar to Bash. A few things to note are:
     * `edit.py` - Open any text type files in Pythonista editor
     * `find.py` - Powerful file searching tool
     * `fg.py` - Bring a background job to foreground
+    * `gci.py - Interface to Python's built-in garbage collector
     * `git.py` - Git client ported from shellista
     * `grep.py` - search contents of file(s)
     * `httpserver.py` - A simple HTTP server with upload function (ripped from
@@ -231,6 +232,8 @@ The usage of StaSh is in principle similar to Bash. A few things to note are:
     * `ls.py` - List files
     * `mail.py` - Send emails with optional file attachment
     * `man.py` - Show help message (docstring) of a given command
+    * `mc.py` - Easily work with multiple filesystems (e.g. local and FTP) 
+      synchronously.
     * `md5sum.py` - Print or check MD5 checksums
     * `mkdir.py` - Create directory
     * `mv.py` - Move file
@@ -293,7 +296,4 @@ The usage of StaSh is in principle similar to Bash. A few things to note are:
   ideas of features and/or bugs
 * Fork the repository, make changes, and send pull requests 
     - Please send pull requests to the **dev** branch instead of master
-
-
-
 

--- a/bin/pip.py
+++ b/bin/pip.py
@@ -276,6 +276,9 @@ def fake_setuptools_modules():
     for m in distutils_command_modules:
         fake_module(m)
     sys.modules['distutils.util'].get_platform = OmniClass()
+    # fix for new problem in issue 169 
+    sys.modules['distutils.command.build_ext'].sub_commands = []
+    sys.modules['setuptools.command.build_ext'].sub_commands = []
 
 
 @contextlib.contextmanager

--- a/bin/python.py
+++ b/bin/python.py
@@ -8,8 +8,8 @@ Can also be used to run a script in the background, such as a server, with the b
 usage:
     python
     python -m module_name [args]
+    python -c command
     python python_file.py [args]
-    python -c cmd
 """
 
 import runpy
@@ -19,39 +19,46 @@ import code
 import __builtin__
 
 ap = argparse.ArgumentParser()
-ap.add_argument('-m', '--module', action='store', default=None, help='run module')
-ap.add_argument('-c', '--cmd', action='store', default=None, help='program passed in as string (terminates option list)')
-ap.add_argument('file', action='store', default=None, help='program read from script file (terminates option list)', nargs='?')#,required=False)
-ap.add_argument('args_to_pass', nargs=argparse.REMAINDER, help='arguments passed to program in sys.argv[1:]')
-args = ap.parse_args()
 
-sys.argv = [sys.argv[0]] + args.args_to_pass
+group = ap.add_mutually_exclusive_group()
+group.add_argument('-m', '--module',
+                   action='store', default=None,
+                   help='run module')
+group.add_argument('-c', '--cmd',
+                   action='store', default=None,
+                   help='program passed in as string (terminates option list)')
 
-if (args.module is not None) and (args.cmd is not None):
-	print 'Error: Please only pass either "-c" or "-m", but not both!'
-	sys.exit(1)
-elif args.module is not None:
-	try:
-		runpy.run_module(str(args.module), run_name='__main__')
-	except ImportError, e:
-		print 'ImportError: ' + str(e)
-		sys.exit(1)
-	sys.exit(0)
+ap.add_argument('args_to_pass',
+                metavar='[file] args_to_pass',
+                nargs=argparse.REMAINDER,
+                help='Python script and arguments')
+ns = ap.parse_args()
 
-elif args.cmd is not None:
-	exec args.cmd
-	sys.exit(0)
+if ns.module:
+    sys.argv = [ns.module] + ns.args_to_pass
+    try:
+        runpy.run_module(str(ns.module), run_name='__main__')
+    except ImportError as e:
+        print('ImportError: ' + str(e))
+        sys.exit(1)
+    sys.exit(0)
 
-elif args.file is not None:
-	try:
-		runpy.run_path(str(args.file), run_name='__main__')
-	except Exception, e:
-		print 'Error: ' + str(e)
+elif ns.cmd:
+    exec ns.cmd
+    sys.exit(0)
+
 else:
-	locals={
-	'__name__':'__main__',
-	'__doc__':None,
-	'__package__':None,
-	'__builtins__':__builtin__,#yes, __builtins__
-	}
-	code.interact(local=locals)
+    if ns.args_to_pass:
+        sys.argv = ns.args_to_pass
+        try:
+            runpy.run_path(str(sys.argv[0]), run_name='__main__')
+        except Exception as e:
+            print('Error: ' + str(e))
+    else:
+        locals = {
+            '__name__': '__main__',
+            '__doc__': None,
+            '__package__': None,
+            '__builtins__': __builtin__,  # yes, __builtins__
+        }
+        code.interact(local=locals)

--- a/bin/python.py
+++ b/bin/python.py
@@ -18,6 +18,13 @@ import argparse
 import code
 import __builtin__
 
+args = sys.argv[1:]
+
+passing_h = False
+if '-h' in args and len(args) > 1:
+    args.remove('-h')
+    passing_h = True
+
 ap = argparse.ArgumentParser()
 
 group = ap.add_mutually_exclusive_group()
@@ -30,9 +37,13 @@ group.add_argument('-c', '--cmd',
 
 ap.add_argument('args_to_pass',
                 metavar='[file] args_to_pass',
+                default=[],
                 nargs=argparse.REMAINDER,
                 help='Python script and arguments')
-ns = ap.parse_args()
+
+ns = ap.parse_args(args)
+if passing_h:
+    ns.args_to_pass.append('-h')
 
 if ns.module:
     sys.argv = [ns.module] + ns.args_to_pass

--- a/bin/python.py
+++ b/bin/python.py
@@ -44,7 +44,7 @@ elif args.cmd is not None:
 
 elif args.file is not None:
 	try:
-		runpy.run_path(str(args.name), run_name='__main__')
+		runpy.run_path(str(args.file), run_name='__main__')
 	except Exception, e:
 		print 'Error: ' + str(e)
 else:

--- a/bin/selfupdate.py
+++ b/bin/selfupdate.py
@@ -17,14 +17,15 @@ from argparse import ArgumentParser
 
 _stash = globals()['_stash']
 
-URL_BASE = 'https://raw.githubusercontent.com/ywangd/stash'
+URL_BASE = 'https://raw.githubusercontent.com/{owner}/stash'
+DEFAULT_REPO_OWNER="ywangd"
 
 
 class UpdateError(Exception):
     pass
 
 
-def get_remote_version(branch):
+def get_remote_version(owner, branch):
     """
     Get the version string for the given branch from the remote repo
     :param branch:
@@ -32,12 +33,16 @@ def get_remote_version(branch):
     """
     import ast
 
-    url = '%s/%s/stash.py?q=%s' % (URL_BASE, branch, randint(1, 999999))
+    url = '%s/%s/stash.py?q=%s' % (URL_BASE.format(owner=owner), branch, randint(1, 999999))
 
     try:
-        lines = requests.get(url).text.splitlines()
+        req = requests.get(url)
+        lines = req.text.splitlines()
     except:
         raise UpdateError('Network error')
+    else:
+        if req.status_code==404:
+            raise UpdateError('Repository/branch not found')
 
     for line in lines:
         if line.startswith('__version__'):
@@ -53,6 +58,7 @@ def main(args):
 
     ap = ArgumentParser()
     ap.add_argument('branch', nargs='?', help='the branch to update to')
+    ap.add_argument('repository', nargs='?', help='the user owning the target repository to update to')
     ap.add_argument('-n', '--check', action='store_true', help='check for update only')
     ap.add_argument('-f', '--force', action='store_true', help='update without checking for new version')
     ns = ap.parse_args(args)
@@ -61,10 +67,15 @@ def main(args):
         SELFUPDATE_BRANCH = ns.branch
     else:
         SELFUPDATE_BRANCH = os.environ.get('SELFUPDATE_BRANCH', 'master')
+    
+    if ns.repository is not None:
+        SELFUPDATE_REPO = ns.repository
+    else:
+        SELFUPDATE_REPO = os.environ.get('SELFUPDATE_REPOSITORY',DEFAULT_REPO_OWNER)
 
     print _stash.text_style('Running selfupdate ...',
                             {'color': 'yellow', 'traits': ['bold']})
-    print u'%s: %s' % (_stash.text_bold('Branch'), SELFUPDATE_BRANCH)
+    print u'%s: %s/%s' % (_stash.text_bold('Branch'), SELFUPDATE_REPO, SELFUPDATE_BRANCH)
 
     has_update = True
     # Check for update if it is not forced updating
@@ -72,7 +83,7 @@ def main(args):
         local_version = globals()['_stash'].__version__
         try:
             print 'Checking for new version ...'
-            remote_version = get_remote_version(SELFUPDATE_BRANCH)
+            remote_version = get_remote_version(SELFUPDATE_REPO, SELFUPDATE_BRANCH)
 
             if StrictVersion(remote_version) > StrictVersion(local_version):
                 print 'New version available: %s' % remote_version
@@ -87,16 +98,16 @@ def main(args):
     # Perform update if new version is available and not just checking only
     if not ns.check and has_update:
 
-        url = '%s/%s/getstash.py' % (URL_BASE, SELFUPDATE_BRANCH)
+        url = '%s/%s/getstash.py' % (URL_BASE.format(owner=SELFUPDATE_REPO), SELFUPDATE_BRANCH)
         print u'%s: %s' % (_stash.text_bold('Url'),
                            _stash.text_style(url, {'color': 'blue', 'traits': ['underline']}))
 
         try:
             exec requests.get(
-                '%s/%s/getstash.py?q=%s' % (URL_BASE,
+                '%s/%s/getstash.py?q=%s' % (URL_BASE.format(owner=SELFUPDATE_REPO),
                                             SELFUPDATE_BRANCH,
                                             randint(1, 999999))
-            ).text in {'_IS_UPDATE': True, '_br': SELFUPDATE_BRANCH}
+            ).text in {'_IS_UPDATE': True, '_br': SELFUPDATE_BRANCH,'_repo':SELFUPDATE_REPO}
             print _stash.text_color('Update completed.', 'green')
             print _stash.text_color('Please restart Pythonista to ensure changes becoming effective.', 'green')
 

--- a/getstash.py
+++ b/getstash.py
@@ -8,11 +8,15 @@ try:
     branch = locals()['_br']
 except KeyError:
     branch = 'master'
+try:
+    repo = locals()['_repo']
+except:
+    repo = 'ywangd'
 
 _IS_UPDATE = '_IS_UPDATE' in locals()
 
 TMPDIR = os.environ.get('TMPDIR', os.environ.get('TMP'))
-URL_ZIPFILE = 'https://github.com/ywangd/stash/archive/{}.zip'.format(branch)
+URL_ZIPFILE = 'https://github.com/{}/stash/archive/{}.zip'.format(repo, branch)
 TEMP_ZIPFILE = os.path.join(TMPDIR, '{}.zip'.format(branch))
 TEMP_PTI = os.path.join(TMPDIR, 'ptinstaller.py')
 URL_PTI = 'https://raw.githubusercontent.com/ywangd/pythonista-tools-installer/master/ptinstaller.py'
@@ -95,4 +99,3 @@ except:
 if not _IS_UPDATE:
     print('Installation completed.')
     print('Please run launch_stash.py under the Home directory to start StaSh.')
-

--- a/getstash.py
+++ b/getstash.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 import sys
-import urllib2
+import requests
 import zipfile
 
 try:
@@ -11,30 +11,32 @@ except KeyError:
 
 _IS_UPDATE = '_IS_UPDATE' in locals()
 
-URL_ZIPFILE = 'https://github.com/ywangd/stash/archive/%s.zip' % branch
-TEMP_ZIPFILE = os.path.join(os.environ.get('TMPDIR', os.environ.get('TMP')),
-                            '%s.zip' % branch)
+TMPDIR = os.environ.get('TMPDIR', os.environ.get('TMP'))
+URL_ZIPFILE = 'https://github.com/ywangd/stash/archive/{}.zip'.format(branch)
+TEMP_ZIPFILE = os.path.join(TMPDIR, '{}.zip'.format(branch))
+TEMP_PTI = os.path.join(TMPDIR, 'ptinstaller.py')
+URL_PTI = 'https://raw.githubusercontent.com/ywangd/pythonista-tools-installer/master/ptinstaller.py'
 
-print('Downloading %s ...' % URL_ZIPFILE)
+print('Downloading {} ...'.format(URL_ZIPFILE))
 
 try:
-    u = urllib2.urlopen(URL_ZIPFILE)
-    meta = u.info()
-    try:
-        file_size = int(meta.getheaders("Content-Length")[0])
-    except IndexError:
-        file_size = None
-    with open(TEMP_ZIPFILE, 'wb') as outs:
-        file_size_dl = 0
-        block_sz = 8192
-        while True:
-            buf = u.read(block_sz)
-            if not buf:
-                break
-            file_size_dl += len(buf)
-            outs.write(buf)
+    r = requests.get(URL_ZIPFILE, stream=True)
+    file_size = r.headers.get('Content-Length')
+    if file_size is not None:
+        file_size = int(file_size)
 
-except:
+    with open(TEMP_ZIPFILE, 'wb') as outs:
+        block_sz = 8192
+        for chunk in r.iter_content(block_sz):
+            outs.write(chunk)
+
+    # Get Pythonista Tools Installer
+    r = requests.get(URL_PTI)
+    with open(TEMP_PTI, 'w') as outs:
+        outs.write(r.text)
+
+except Exception as e:
+    sys.stderr.write('{}\n'.format(e))
     sys.stderr.write('Download failed! Please make sure internet connection is available.\n')
     sys.exit(1)
 
@@ -68,10 +70,17 @@ with open(TEMP_ZIPFILE, 'rb') as ins:
         sys.exit(1)
 
 print('Preparing the folder structure ...')
-shutil.copy(os.path.join(TARGET_DIR, 'launch_stash.py'),
+# Move ptinstaller.py to bin
+shutil.move(TEMP_PTI, os.path.join(TARGET_DIR, 'bin/ptinstaller.py'))
+
+# Move launch script to Documents for easy access
+shutil.move(os.path.join(TARGET_DIR, 'launch_stash.py'),
             os.path.join(BASE_DIR, 'Documents/launch_stash.py'))
 
+# Remove setup files and possible legacy files
 try:
+    os.remove(TEMP_ZIPFILE)
+
     shutil.rmtree(os.path.join(TARGET_DIR, 'tests'))
 
     unwanted_files = ['getstash.py', 'run_tests.py', 'testing.py', 

--- a/stash.py
+++ b/stash.py
@@ -5,7 +5,7 @@ StaSh - Pythonista Shell
 https://github.com/ywangd/stash
 """
 
-__version__ = '0.6.7'
+__version__ = '0.6.8'
 
 import os
 import sys

--- a/stash.py
+++ b/stash.py
@@ -77,13 +77,14 @@ class StaSh(object):
     utility interfaces to running scripts.
     """
 
-    def __init__(self, debug=(), log_setting=None):
+    def __init__(self, debug=(), log_setting=None,
+                 no_cfgfile=False, no_rcfile=False, no_historyfile=False):
         self.__version__ = __version__
 
         # Intercept IO
         enable_io_wrapper()
 
-        self.config = self._load_config()
+        self.config = self._load_config(no_cfgfile=no_cfgfile)
         self.logger = self._config_logging(log_setting)
 
         self.user_action_proxy = ShUserActionProxy(self)
@@ -113,13 +114,14 @@ class StaSh(object):
 
         parser = ShParser(debug=_DEBUG_PARSER in debug)
         expander = ShExpander(self, debug=_DEBUG_EXPANDER in debug)
-        self.runtime = ShRuntime(self, parser, expander, debug=_DEBUG_RUNTIME in debug)
+        self.runtime = ShRuntime(self, parser, expander, no_historyfile=no_historyfile,
+                                 debug=_DEBUG_RUNTIME in debug)
         self.completer = ShCompleter(self, debug=_DEBUG_COMPLETER in debug)
 
         # Navigate to the startup folder
         if IN_PYTHONISTA:
             os.chdir(self.runtime.state.environ_get('HOME2'))
-        self.runtime.load_rcfile()
+        self.runtime.load_rcfile(no_rcfile=no_rcfile)
         self.io.write(self.text_style('StaSh v%s\n' % self.__version__,
                                       {'color': 'blue', 'traits': ['bold']},
                                       always=True))
@@ -138,13 +140,15 @@ class StaSh(object):
         return worker
 
     @staticmethod
-    def _load_config():
+    def _load_config(no_cfgfile=False):
         config = ConfigParser()
         config.optionxform = str  # make it preserve case
         # defaults
         config.readfp(StringIO(_DEFAULT_CONFIG))
+
         # update from config file
-        config.read(os.path.join(_STASH_ROOT, f) for f in _STASH_CONFIG_FILES)
+        if not no_cfgfile:
+            config.read(os.path.join(_STASH_ROOT, f) for f in _STASH_CONFIG_FILES)
 
         return config
 

--- a/system/shcommon.py
+++ b/system/shcommon.py
@@ -16,10 +16,9 @@ PYTHONISTA_VERSION = '0.0'
 PYTHONISTA_VERSION_LONG = '000000'
 if IN_PYTHONISTA:
     import plistlib
-    PYTHONISTA_VERSION = plistlib.readPlist(
-        os.path.join(os.path.dirname(sys.executable), 'Info.plist'))['CFBundleShortVersionString']
-    PYTHONISTA_VERSION_LONG = plistlib.readPlist(
-        os.path.join(os.path.dirname(sys.executable), 'Info.plist'))['CFBundleVersion']
+    _properties = plistlib.readPlist(os.path.join(os.path.dirname(sys.executable), 'Info.plist'))
+    PYTHONISTA_VERSION = _properties['CFBundleShortVersionString']
+    PYTHONISTA_VERSION_LONG = _properties['CFBundleVersion']
 
 platform_string = platform.platform()
 

--- a/system/shcommon.py
+++ b/system/shcommon.py
@@ -13,10 +13,13 @@ from itertools import chain
 IN_PYTHONISTA = sys.executable.find('Pythonista') >= 0
 
 PYTHONISTA_VERSION = '0.0'
+PYTHONISTA_VERSION_LONG = '000000'
 if IN_PYTHONISTA:
     import plistlib
     PYTHONISTA_VERSION = plistlib.readPlist(
         os.path.join(os.path.dirname(sys.executable), 'Info.plist'))['CFBundleShortVersionString']
+    PYTHONISTA_VERSION_LONG = plistlib.readPlist(
+        os.path.join(os.path.dirname(sys.executable), 'Info.plist'))['CFBundleVersion']
 
 platform_string = platform.platform()
 

--- a/system/shruntime.py
+++ b/system/shruntime.py
@@ -45,7 +45,7 @@ class ShRuntime(object):
     Runtime class responsible for parsing and executing commands.
     """
 
-    def __init__(self, stash, parser, expander, debug=False):
+    def __init__(self, stash, parser, expander, no_historyfile=False, debug=False):
         self.stash = stash
         self.parser = parser
         self.expander = expander
@@ -84,11 +84,14 @@ class ShRuntime(object):
 
         # load history from last session
         # NOTE the first entry in history is the latest one
-        try:
-            with open(self.historyfile) as ins:
-                # History from old to new, history at 0 is the oldest
-                self.history = [line.strip() for line in ins.readlines()]
-        except IOError:
+        if not no_historyfile:
+            try:
+                with open(self.historyfile) as ins:
+                    # History from old to new, history at 0 is the oldest
+                    self.history = [line.strip() for line in ins.readlines()]
+            except IOError:
+                self.history = []
+        else:
             self.history = []
         self.history_alt = []
 
@@ -97,13 +100,12 @@ class ShRuntime(object):
         self.idx_to_history = -1
         self.history_templine = ''
 
-    def load_rcfile(self):
+    def load_rcfile(self, no_rcfile=False):
         self.stash(_DEFAULT_RC.splitlines(),
                    persistent_level=1,
                    add_to_history=False, add_new_inp_line=False)
 
-        # TODO: NO RC FILE loading
-        if os.path.exists(self.rcfile) and os.path.isfile(self.rcfile):
+        if not no_rcfile and os.path.exists(self.rcfile) and os.path.isfile(self.rcfile):
             try:
                 with open(self.rcfile) as ins:
                     self.stash(ins.readlines(),

--- a/system/shui.py
+++ b/system/shui.py
@@ -287,12 +287,10 @@ class ShUI(ui.View):
         Save stuff here
         :return:
         """
-        # TODO: temporarily disable will_close for pythonista 3 betas
-        if PYTHONISTA_VERSION_LONG < '300010':
-            self.stash.runtime.save_history()
-            self.stash.cleanup()
-            # Clear the stack or the stdout becomes unusable for interactive prompt
-            self.stash.runtime.worker_registry.purge()
+        self.stash.runtime.save_history()
+        self.stash.cleanup()
+        # Clear the stack or the stdout becomes unusable for interactive prompt
+        self.stash.runtime.worker_registry.purge()
 
     def toggle_k_grp(self):
         if self.on_k_grp == 0:

--- a/system/shui.py
+++ b/system/shui.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     import dummyui as ui
 
-from .shcommon import IN_PYTHONISTA, ON_IPAD
+from .shcommon import IN_PYTHONISTA, ON_IPAD, PYTHONISTA_VERSION_LONG
 from .shterminal import ShTerminal, StubTerminal
 
 class ShVk(ui.View):
@@ -287,10 +287,12 @@ class ShUI(ui.View):
         Save stuff here
         :return:
         """
-        self.stash.runtime.save_history()
-        self.stash.cleanup()
-        # Clear the stack or the stdout becomes unusable for interactive prompt
-        self.stash.runtime.worker_registry.purge()
+        # TODO: temporarily disable will_close for pythonista 3 betas
+        if PYTHONISTA_VERSION_LONG > '300010':
+            self.stash.runtime.save_history()
+            self.stash.cleanup()
+            # Clear the stack or the stdout becomes unusable for interactive prompt
+            self.stash.runtime.worker_registry.purge()
 
     def toggle_k_grp(self):
         if self.on_k_grp == 0:

--- a/system/shui.py
+++ b/system/shui.py
@@ -288,7 +288,7 @@ class ShUI(ui.View):
         :return:
         """
         # TODO: temporarily disable will_close for pythonista 3 betas
-        if PYTHONISTA_VERSION_LONG > '300010':
+        if PYTHONISTA_VERSION_LONG < '300010':
             self.stash.runtime.save_history()
             self.stash.cleanup()
             # Clear the stack or the stdout becomes unusable for interactive prompt


### PR DESCRIPTION
The selfupdate command and the getstash.py script now supports updating to/from a different repo (`selfupdate dev bennr01` will update to the `dev` branch of `bennr01`).
Also, the `selfupdate`-command now checks wether branch and repo exists when called without the `-f` option (`selfupdate -f` will not check wether the request results in a `404` because  the forced update should not do any checks. If the repo does not exists and the command is called with `-f`, `raw.githubusercontent.com` will return the text `Not Found`, resulting in a `SyntaxError` which will prevent the update).
I have tested the `selfupdate.py` and `getstash.py` scripts with all possible command-combinations i could think of, see the comments on https://github.com/bennr01/stash/commit/fc4862baebce49766a9fcb41328aa0312f82dc5a for more info abot the tests.
